### PR TITLE
Add Dependencies for roles

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -34,7 +34,8 @@ client.on('ready', async () => {
       },
       {
         emoji: '<:EMOJI_NAME:EMOJI_ID>',
-        role: 'ROLE_ID'
+        role: 'ROLE_ID',
+        requiredRole: ['OTHER_ROLE_ID'],
       }
     ],
     message: {

--- a/example/index.js
+++ b/example/index.js
@@ -111,13 +111,13 @@ manager.on('maxRolesReach', async (member, userAction, nbRoles, maxRoles) => {
 manager.on('interaction', (rte, interaction) =>
   console.log(`An interaction has been made by ${interaction.member.displayName}`)
 );
-manager.on('conditionsNotMet', async (member,
+manager.on('requiredRolesMissing', async (member,
   userAction,
   role,
   dependencies) => {
-  console.log(`${member.displayName} doesn't have the required dependencies to get the role ${role}!`, dependencies);
+  console.log(`${member.displayName} doesn't have the required roles to get the role ${role}!`, dependencies);
   userAction instanceof ButtonInteraction && await userAction.editReply({
-    content: `${member.displayName} doesn't have the required dependencies to get the role ${role}!`
+    content: `${member.displayName} doesn't have the required roles to get the role ${role}!`
   });
 });
 

--- a/example/index.js
+++ b/example/index.js
@@ -108,10 +108,7 @@ manager.on('maxRolesReach', async (member, userAction, nbRoles, maxRoles) => {
 manager.on('interaction', (rte, interaction) =>
   console.log(`An interaction has been made by ${interaction.member.displayName}`)
 );
-manager.on('requiredRolesMissing', async (member,
-  userAction,
-  role,
-  dependencies) => {
+manager.on('requiredRolesMissing', async (member, userAction, role, dependencies) => {
   console.log(`${member.displayName} doesn't have the required roles to get the role ${role}!`, dependencies);
   userAction instanceof ButtonInteraction && await userAction.editReply({
     content: `${member.displayName} doesn't have the required roles to get the role ${role}!`

--- a/example/index.js
+++ b/example/index.js
@@ -35,7 +35,7 @@ client.on('ready', async () => {
       {
         emoji: '<:EMOJI_NAME:EMOJI_ID>',
         role: 'ROLE_ID',
-        requiredRole: ['OTHER_ROLE_ID'],
+        requiredRoles: ['OTHER_ROLE_ID'],
       }
     ],
     message: {

--- a/example/index.js
+++ b/example/index.js
@@ -107,5 +107,14 @@ manager.on('maxRolesReach', async (member, userAction, nbRoles, maxRoles) => {
 manager.on('interaction', (rte, interaction) =>
   console.log(`An interaction has been made by ${interaction.member.displayName}`)
 );
+manager.on('conditionsNotMet', async (member,
+  userAction,
+  role,
+  dependencies) => {
+  console.log(`${member.displayName} doesn't have the required dependencies to get the role ${role}!`, dependencies);
+  userAction instanceof ButtonInteraction && await userAction.editReply({
+    content: `${member.displayName} doesn't have the required dependencies to get the role ${role}!`
+  });
+});
 
 client.login('TOKEN');

--- a/example/index.js
+++ b/example/index.js
@@ -79,10 +79,14 @@ manager.on('messageDelete', (message) =>
   console.log(`Message ${message.id} deleted!`)
 );
 manager.on('roleRemove', async (role, member, userAction) => {
-  console.log(`Role ${role} removed from ${member.displayName}`);
-  userAction instanceof ButtonInteraction && await userAction.editReply({
-    content: `Your old role ${role} has been removed from you.`,
-  });
+  if (userAction === null) {
+    console.log(`Role ${role} automatically removed from ${member.displayName}.`);
+  } else {
+    console.log(`Role ${role} removed from ${member.displayName}`);
+    userAction instanceof ButtonInteraction && await userAction.editReply({
+      content: `Your old role ${role} has been removed from you.`,
+    });
+  }
 });
 manager.on('roleAdd', async (role, member, userAction) => {
   console.log(`Role ${role} given to ${member.displayName}`);

--- a/example/index.js
+++ b/example/index.js
@@ -80,14 +80,10 @@ manager.on('messageDelete', (message) =>
   console.log(`Message ${message.id} deleted!`)
 );
 manager.on('roleRemove', async (role, member, userAction) => {
-  if (userAction === null) {
-    console.log(`Role ${role} automatically removed from ${member.displayName}.`);
-  } else {
-    console.log(`Role ${role} removed from ${member.displayName}`);
-    userAction instanceof ButtonInteraction && await userAction.editReply({
-      content: `Your old role ${role} has been removed from you.`,
-    });
-  }
+  console.log(`Role ${role} ${userAction ? '' : 'automatically '}removed from ${member.displayName}`);
+  userAction && userAction instanceof ButtonInteraction && await userAction.editReply({
+    content: `Your old role ${role} has been removed from you.`,
+  });
 });
 manager.on('roleAdd', async (role, member, userAction) => {
   console.log(`Role ${role} given to ${member.displayName}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hunteroi/discord-selfrole",
-  "version": "2.2.3",
+  "version": "3.0.0",
   "description": "A framework to integrate a channel with a automated role-giver system inside your Discord bot built with DiscordJS",
   "main": "lib/index.js",
   "scripts": {

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -28,6 +28,7 @@ import {
 import { SelfRoleManagerEvents } from './SelfRoleManagerEvents';
 import { ChannelOptions, RoleToEmojiData, SelfRoleOptions } from './types';
 import { isNullOrWhiteSpaces, addRole, removeRole, constructMessageOptions } from './utils';
+import type { UserAction } from './types/UserAction';
 
 /**
  * The manager handling assignation and removal of roles based on user interactions/reactions.
@@ -299,7 +300,7 @@ export class SelfRoleManager extends EventEmitter {
         const roleToRemove = role instanceof Role ? role.id : role;
           const user = await removeRole(newMember, roleToRemove);
           if (user) {
-            this.emit(SelfRoleManagerEvents.roleRemove, roleToRemove, newMember);
+            this.emit(SelfRoleManagerEvents.roleRemove, roleToRemove, newMember, null);
           }
       }
     });
@@ -364,7 +365,7 @@ export class SelfRoleManager extends EventEmitter {
  * @event SelfRoleManager#roleRemove
  * @param {RoleResolvable} role
  * @param {GuildMember} member
- * @param {ButtonInteraction | MessageReaction | PartialMessageReaction} userAction
+ * @param {UserAction} userAction
  * @example
  * manager.on(SelfRoleManagerEvents.roleRemove, (role, member, userAction) => {});
  */
@@ -374,7 +375,7 @@ export class SelfRoleManager extends EventEmitter {
  * @event SelfRoleManager#roleAdd
  * @param {RoleResolvable} role
  * @param {GuildMember} member
- * @param {ButtonInteraction | MessageReaction | PartialMessageReaction} userAction
+ * @param {UserAction} userAction
  * @example
  * manager.on(SelfRoleManagerEvents.roleAdd, (role, member, userAction) => {});
  */
@@ -401,7 +402,7 @@ export class SelfRoleManager extends EventEmitter {
  * Emitted when the maximum of roles is reached for the member.
  * @event SelfRoleManager#maxRolesReach
  * @param {GuildMember} member
- * @param {ButtonInteraction | MessageReaction | PartialMessageReaction} userAction
+ * @param {UserAction} userAction
  * @param {number | null} nbRoles
  * @param {number | null} maximumRoles
  * @example
@@ -421,7 +422,7 @@ export class SelfRoleManager extends EventEmitter {
  * Emitted when the user wants a role but does not have the required roles to apply for it.
  * @event SelfRoleManager#conditionsNotMet
  * @param {GuildMember} member
- * @param {ButtonInteraction | MessageReaction | PartialMessageReaction} userAction
+ * @param {UserAction} userAction
  * @param {Role} role the role to add
  * @param {RoleResolvable[]} requiredRoles the required roles to pass the conditions
  * @example

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -289,7 +289,7 @@ export class SelfRoleManager extends EventEmitter {
     }
   }
 
-  #rolesChangesListener(rolesToEmojis: RoleToEmojiData[]) : (oldMember: GuildMember | PartialGuildMember, newMember: GuildMember) => Promise<void> {
+  #generateRolesChangesListener(rolesToEmojis: RoleToEmojiData[]) : (oldMember: GuildMember | PartialGuildMember, newMember: GuildMember) => Promise<void> {
     return async (oldMember: GuildMember | PartialGuildMember, newMember: GuildMember) => {
       const rolesToRemove = rolesToEmojis.filter(
         (rte) =>

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -289,7 +289,7 @@ export class SelfRoleManager extends EventEmitter {
     }
   }
 
-  #rolesChangesListener(rolesToEmojis: RoleToEmojiData[]) {
+  #rolesChangesListener(rolesToEmojis: RoleToEmojiData[]) : (oldMember: GuildMember | PartialGuildMember, newMember: GuildMember) => Promise<void> {
     return async (oldMember: GuildMember | PartialGuildMember, newMember: GuildMember) => {
       const rolesToRemove = rolesToEmojis.filter(
         (rte) =>

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -21,7 +21,6 @@ import {
   ReactionEmoji,
   APIMessageComponentEmoji,
   GuildMember,
-  RoleResolvable,
   Events
 } from 'discord.js';
 

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -142,7 +142,7 @@ export class SelfRoleManager extends EventEmitter {
       const properties = this.channels.get(channelID);
       const isDeleted = this.channels.delete(channelID);
       if (isDeleted) {
-        this.client.off(Events.GuildMemberUpdate, properties._rolesChangesListener);
+        this.client.off(Events.GuildMemberUpdate, properties.rolesChangesListener);
         this.emit(SelfRoleManagerEvents.channelUnregister, channel, properties.options);
       } else {
         this.emit(SelfRoleManagerEvents.error, null, `The channel with the id ${channelID} could not get unregistered`);

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -294,8 +294,10 @@ export class SelfRoleManager extends EventEmitter {
       for (const { role } of rolesToRemove) {
         const roleToRemove = role instanceof Role ? role.id : role;
         if (newMember.roles.cache.has(roleToRemove)) {
-          await removeRole(newMember, roleToRemove);
-          this.emit(SelfRoleManagerEvents.roleRemove, roleToRemove, newMember);
+          const user = await removeRole(newMember, roleToRemove);
+          if (user) {
+            this.emit(SelfRoleManagerEvents.roleRemove, roleToRemove, newMember);
+          }
         }
       }
     });

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -205,7 +205,7 @@ export class SelfRoleManager extends EventEmitter {
     }
 
     const rolesChangesListener = this.#generateRolesChangesListener(channelOptions.rolesToEmojis).bind(this);
-    this.client.on(Events.GuildMemberUpdate, listener );
+    this.client.on(Events.GuildMemberUpdate, rolesChangesListener);
     if (!this.channels.has(channel.id)) {
       this.channels.set(channel.id, { options: { ...channelOptions, message: { ...channelOptions.message, id: message.id } }, rolesChangesListener });
     }

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -204,7 +204,7 @@ export class SelfRoleManager extends EventEmitter {
       }
     }
 
-    const listener = this.#rolesChangesListener(channelOptions.rolesToEmojis);
+    const listener = this.#rolesChangesListener(channelOptions.rolesToEmojis).bind(this);
     this.client.on(Events.GuildMemberUpdate, listener );
     if (!this.channels.has(channel.id)) {
       this.channels.set(channel.id, { ...channelOptions, message: { ...channelOptions.message, id: message.id }, _rolesChangesListener: listener });

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -262,7 +262,7 @@ export class SelfRoleManager extends EventEmitter {
     const userWantsToRemoveRole = isButtonInteraction ? memberHasRole : memberHasRole && ((!rteData.removeOnReact && isReactionRemoval) || (rteData.removeOnReact && !isReactionRemoval));
     const userWantsToAddRole = isButtonInteraction ? !memberHasRole : !memberHasRole && ((!rteData.removeOnReact && !isReactionRemoval) || (rteData.removeOnReact && isReactionRemoval));
     const role: Role = rteData.role instanceof Role ? rteData.role : await userAction.message.guild.roles.fetch(rteData.role);
-    const userMeetsConditions = rteData.requiredRoles
+    const userHasRequiredRoles  = rteData.requiredRoles
       ?.every(role => role instanceof Role
         ? memberRoles.includes(role)
         : memberRoles.map(r => r.id).includes(role)
@@ -273,7 +273,7 @@ export class SelfRoleManager extends EventEmitter {
       case userWantsToAddRole && maxRolesReached:
         this.emit(SelfRoleManagerEvents.maxRolesReach, member, userAction, memberManagedRoles.length, channelOptions.maxRolesAssigned);
         break;
-      case userWantsToAddRole && !userMeetsConditions:
+      case userWantsToAddRole && !userHasRequiredRoles :
         this.emit(SelfRoleManagerEvents.requiredRolesMissing, member, userAction, role, rteData.requiredRoles);
         break;
       case userWantsToAddRole:

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -272,7 +272,7 @@ export class SelfRoleManager extends EventEmitter {
         this.emit(SelfRoleManagerEvents.maxRolesReach, member, userAction, memberManagedRoles.length, channelOptions.maxRolesAssigned);
         break;
       case userWantsToAddRole && !userMeetsConditions:
-        this.emit(SelfRoleManagerEvents.conditionsNotMet, member, userAction, role, rteData.requiredRoles);
+        this.emit(SelfRoleManagerEvents.requiredRolesMissing, member, userAction, role, rteData.requiredRoles);
         break;
       case userWantsToAddRole:
         updatedMember = await addRole(member, role);
@@ -420,11 +420,11 @@ export class SelfRoleManager extends EventEmitter {
 
 /**
  * Emitted when the user wants a role but does not have the required roles to apply for it.
- * @event SelfRoleManager#conditionsNotMet
+ * @event SelfRoleManager#requiredRolesMissing
  * @param {GuildMember} member
  * @param {UserAction} userAction
  * @param {Role} role the role to add
  * @param {RoleResolvable[]} requiredRoles the required roles to pass the conditions
  * @example
- * manager.on(SelfRoleManagerEvents.conditionsNotMet, (member, userAction, role, requiredRoles) => {});
+ * manager.on(SelfRoleManagerEvents.requiredRolesMissing, (member, userAction, role, requiredRoles) => {});
  */

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -143,7 +143,7 @@ export class SelfRoleManager extends EventEmitter {
       const isDeleted = this.channels.delete(channelID);
       if (isDeleted) {
         this.client.off(Events.GuildMemberUpdate, properties._rolesChangesListener);
-        this.emit(SelfRoleManagerEvents.channelUnregister, channel, properties);
+        this.emit(SelfRoleManagerEvents.channelUnregister, channel, properties.options);
       } else {
         this.emit(SelfRoleManagerEvents.error, null, `The channel with the id ${channelID} could not get unregistered`);
       }

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -292,17 +292,15 @@ export class SelfRoleManager extends EventEmitter {
         (rte) =>
           rte.requiredRoles?.some((dep) => {
             const role = dep instanceof Role ? dep.id : dep;
-            return oldMember.roles.cache.has(role) && !newMember.roles.cache.has(role);
+            return oldMember.roles.resolve(role) && !newMember.roles.resolve(role);
           }) ?? false
       );
       for (const { role } of rolesToRemove) {
         const roleToRemove = role instanceof Role ? role.id : role;
-        if (newMember.roles.cache.has(roleToRemove)) {
           const user = await removeRole(newMember, roleToRemove);
           if (user) {
             this.emit(SelfRoleManagerEvents.roleRemove, roleToRemove, newMember);
           }
-        }
       }
     });
   }

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -207,7 +207,7 @@ export class SelfRoleManager extends EventEmitter {
     const rolesChangesListener = this.#generateRolesChangesListener(channelOptions.rolesToEmojis).bind(this);
     this.client.on(Events.GuildMemberUpdate, listener );
     if (!this.channels.has(channel.id)) {
-      this.channels.set(channel.id, {options: { ...channelOptions, message: { ...channelOptions.message, id: message.id } }, _rolesChangesListener: listener});
+      this.channels.set(channel.id, { options: { ...channelOptions, message: { ...channelOptions.message, id: message.id } }, rolesChangesListener });
     }
   }
 

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -204,7 +204,7 @@ export class SelfRoleManager extends EventEmitter {
       }
     }
 
-    const listener = this.#rolesChangesListener(channelOptions.rolesToEmojis).bind(this);
+    const rolesChangesListener = this.#generateRolesChangesListener(channelOptions.rolesToEmojis).bind(this);
     this.client.on(Events.GuildMemberUpdate, listener );
     if (!this.channels.has(channel.id)) {
       this.channels.set(channel.id, {options: { ...channelOptions, message: { ...channelOptions.message, id: message.id } }, _rolesChangesListener: listener});

--- a/src/SelfRoleManager.ts
+++ b/src/SelfRoleManager.ts
@@ -291,8 +291,7 @@ export class SelfRoleManager extends EventEmitter {
     this.client.on(Events.GuildMemberUpdate, async (oldMember, newMember) => {
       const rolesToRemove = rolesToEmojis.filter(
         (rte) =>
-          rte.requiredRoles?.some((dep) => {
-            const role = dep instanceof Role ? dep.id : dep;
+          rte.requiredRoles?.some((role) => {
             return oldMember.roles.resolve(role) && !newMember.roles.resolve(role);
           }) ?? false
       );

--- a/src/SelfRoleManagerEvents.ts
+++ b/src/SelfRoleManagerEvents.ts
@@ -14,7 +14,7 @@ export enum SelfRoleManagerEvents {
   interaction = 'interaction',
 
   maxRolesReach = 'maxRolesReach',
-  conditionsNotMet = 'conditionsNotMet',
+  requiredRolesMissing = 'requiredRolesMissing',
 
   error = 'error',
 }

--- a/src/SelfRoleManagerEvents.ts
+++ b/src/SelfRoleManagerEvents.ts
@@ -14,7 +14,7 @@ export enum SelfRoleManagerEvents {
   interaction = 'interaction',
 
   maxRolesReach = 'maxRolesReach',
-  notMetDependencies = 'notMetDependencies',
+  conditionsNotMet = 'conditionsNotMet',
 
   error = 'error',
 }

--- a/src/SelfRoleManagerEvents.ts
+++ b/src/SelfRoleManagerEvents.ts
@@ -14,6 +14,7 @@ export enum SelfRoleManagerEvents {
   interaction = 'interaction',
 
   maxRolesReach = 'maxRolesReach',
+  notMetDependencies = 'notMetDependencies',
 
   error = 'error',
 }

--- a/src/types/ChannelOptions.ts
+++ b/src/types/ChannelOptions.ts
@@ -1,4 +1,4 @@
-import { Snowflake } from 'discord.js';
+import { Awaitable, GuildMember, PartialGuildMember, Snowflake } from 'discord.js';
 
 import { MessageOptions } from './MessageOptions';
 import { RoleToEmojiData } from './RoleToEmojiData';
@@ -43,4 +43,12 @@ export interface ChannelOptions {
    * @type {number}
    */
   maxRolesAssigned?: number;
+
+  /**
+   * Private member to store the function for event listener `GuildMemberUpdate`.
+   *
+   * @private
+   * @type {Function}
+   */
+  readonly _rolesChangesListener: (oldMember: GuildMember | PartialGuildMember, newMember: GuildMember) => Awaitable<void>;
 }

--- a/src/types/ChannelOptions.ts
+++ b/src/types/ChannelOptions.ts
@@ -43,12 +43,4 @@ export interface ChannelOptions {
    * @type {number}
    */
   maxRolesAssigned?: number;
-
-  /**
-   * Private member to store the function for event listener `GuildMemberUpdate`.
-   *
-   * @private
-   * @type {Function}
-   */
-  readonly _rolesChangesListener: (oldMember: GuildMember | PartialGuildMember, newMember: GuildMember) => Awaitable<void>;
 }

--- a/src/types/ChannelOptions.ts
+++ b/src/types/ChannelOptions.ts
@@ -1,4 +1,4 @@
-import { Awaitable, GuildMember, PartialGuildMember, Snowflake } from 'discord.js';
+import { Snowflake } from 'discord.js';
 
 import { MessageOptions } from './MessageOptions';
 import { RoleToEmojiData } from './RoleToEmojiData';

--- a/src/types/ChannelProperties.ts
+++ b/src/types/ChannelProperties.ts
@@ -15,9 +15,9 @@ export interface ChannelProperties {
   options: ChannelOptions;
 
    /**
-   * function for event listener `GuildMemberUpdate`.
+   * The listener for the `GuildMemberUpdate` event.
    *
    * @type {Function}
    */
-  _rolesChangesListener: (oldMember: GuildMember | PartialGuildMember, newMember: GuildMember) => Promise<void>;
+  rolesChangesListener: (oldMember: GuildMember | PartialGuildMember, newMember: GuildMember) => Promise<void>;
 }

--- a/src/types/ChannelProperties.ts
+++ b/src/types/ChannelProperties.ts
@@ -1,0 +1,23 @@
+import { GuildMember, PartialGuildMember } from 'discord.js';
+import { ChannelOptions } from './ChannelOptions';
+
+/**
+ *
+ * @export
+ * @interface ChannelProperties
+ */
+export interface ChannelProperties {
+  /**
+   * The option defined by the user for a channel.
+   *
+   * @type {ChannelOptions}
+   */
+  options: ChannelOptions;
+
+   /**
+   * function for event listener `GuildMemberUpdate`.
+   *
+   * @type {Function}
+   */
+  _rolesChangesListener: (oldMember: GuildMember | PartialGuildMember, newMember: GuildMember) => Promise<void>;
+}

--- a/src/types/RoleToEmojiData.ts
+++ b/src/types/RoleToEmojiData.ts
@@ -43,5 +43,5 @@ export interface RoleToEmojiData {
    * @type {RoleResolvable[]}
    * @memberof RoleToEmojiData
    */
-  dependencies?: RoleResolvable[];
+  requiredRoles?: RoleResolvable[];
 }

--- a/src/types/RoleToEmojiData.ts
+++ b/src/types/RoleToEmojiData.ts
@@ -36,4 +36,12 @@ export interface RoleToEmojiData {
    * @memberof RoleToEmojiData
    */
   removeOnReact?: boolean;
+
+  /**
+   * List of required roles to be able to react to this role.
+   *
+   * @type {RoleResolvable[]}
+   * @memberof RoleToEmojiData
+   */
+  dependencies?: RoleResolvable[];
 }

--- a/src/types/UserAction.ts
+++ b/src/types/UserAction.ts
@@ -1,0 +1,3 @@
+import { ButtonInteraction, MessageReaction, PartialMessageReaction } from "discord.js";
+
+export type UserAction = ButtonInteraction | MessageReaction | PartialMessageReaction | null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from './ChannelOptions';
 export * from './MessageOptions';
 export * from './RoleToEmojiData';
 export * from './SelfRoleOptions';
+export * from './ChannelProperties';


### PR DESCRIPTION
Some roles require other roles to be applied. With the `dependencies` property, you can add roles required for a specific role. 

The list works as an `and`, all roles in the table are required.

If one of the required roles is removed from a user. The role is automatically removed.